### PR TITLE
Require 'golang/dep' has been installed 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
     allow_failures:
         - go: master
 
+before_install:
+    # https://github.com/golang/dep
+    - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
 script:
     - make travis -j 8
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@exit 1
 
 clean: ## Remove the exec binary.
-	rm -rf ./$(DIST_NAME)
+	rm -rf $(CURDIR)/$(DIST_NAME)
 
 bootstrap:
 	rm -rf vendor/
@@ -20,10 +20,10 @@ bootstrap:
 build: $(DIST_NAME) ## Build the exec binary for youe machine.
 
 build_linux_x64: ## Just an alias to build for some cloud instance.
-	env GOOS=linux GOARCH=amd64 make build -C .
+	env GOOS=linux GOARCH=amd64 make build -C $(CURDIR)
 
 run: $(DIST_NAME) ## Execute the binary for youe machine.
-	./$(DIST_NAME)
+	$(CURDIR)/$(DIST_NAME)
 
 $(DIST_NAME): clean
 	go build -o $(DIST_NAME) -ldflags "-X main.revision=$(GIT_REVISION) -X \"main.builddate=$(BUILD_DATE)\""
@@ -32,7 +32,7 @@ test: test_epic test_input test_operation test_queue test_setting
 	go test
 
 test_%:
-	make test -C ./$*
+	make test -C $(CURDIR)/$*
 
 travis:
 	make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ clean: ## Remove the exec binary.
 
 bootstrap:
 	rm -rf vendor/
-	go get -u github.com/golang/dep/...
 	dep ensure
 
 build: $(DIST_NAME) ## Build the exec binary for youe machine.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Auto-Merging behaves like this:
 
 ### Build & Launch the Application
 
+0. This requires that [`github.com/golang/dep`](https://github.com/golang/dep) has been installed.
 1. Build from the source.
     - Run these steps:
         1. `make bootstrap`.


### PR DESCRIPTION
When we had started to use [`golang/dep`](https://github.com/golang/dep), there was no _official_ installing way. We use install it directly with `go get`.

Now, `golang/dep` provides a default installing way. So we should use it.