### PR TITLE
Support handling CheckSuiteEvent to merge automatically

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,11 +17,11 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:3e338088ae8edaff386d4a90f89fc058dde595ce426fd5e9e8fb610032d0fcdc"
+  digest = "1:73ad2c6ea4dfacaf6fcb3cc1595b93bf2698380d95e10ead5b607abbdf8d0b7d"
   name = "github.com/google/go-github"
   packages = ["github"]
   pruneopts = ""
-  revision = "e7bb4b8ce29fb7beaf0765acda602bc516a56dd5"
+  revision = "a5cb647b1fac8ba77e1cf25af2f9526658ab63e3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,4 +5,4 @@
 
 [[constraint]]
   name = "github.com/google/go-github"
-  revision = "e7bb4b8ce29fb7beaf0765acda602bc516a56dd5"
+  revision = "a5cb647b1fac8ba77e1cf25af2f9526658ab63e3"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ Auto-Merging behaves like this:
 3. Set `http://<your_server_with_port>/github` for the webhook to your repository with these events:
     - `Issue comment`
     - `Push`
-    - `Status` (required to use Auto-Merging feature).
+    - `Status` (required to use Auto-Merging feature (non GitHub App CI services)).
+    - `Check Suite` (required to use Auto-Merging feature (GitHub App CI Services)).
     - `Pull Request` (required to remove all status (`S-` prefixed) labels after a pull request is closed).
 4. Create these labels to make the status visible.
     - `S-awaiting-review`


### PR DESCRIPTION
`travis-ci.org` notifies build result by webhook.
popuko can subscribe this notification by `StatusEvent`.

Now, TravisCI recommends us that using `travic-ci.com`
https://docs.travis-ci.com/user/open-source-on-travis-ci-com/

But `travis-ci.com` is based on GitHub App, and it notifies by `CheckRunEvent` and `CheckSuiteEvent`.

CheckSuiteEvent has summarize property of CheckRunEvent, so I implemented `CheckSuiteEvent` handler.

example:
travis-ci.org => https://github.com/yamachu/popukoTesterLegacy/pull/1
travis-ci.com => https://github.com/yamachu/popukoTesterNext/pull/1