### PR TITLE
Drop building with Go's master from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: go
 
 go:
     - "1.14"
-    - master
-
-matrix:
-    allow_failures:
-        - go: master
 
 script:
     - make travis -j 8


### PR DESCRIPTION
When I added this option, then we develop this project aggressively, and Go toolchain also changes aggressively by their version up.

However, the situation is changed.

1. This project is almost maintaince mode.
    * We would not have any strong motivation to check the project built with latest nightly Go toolchain.
2. Go toolchain looks mild about upgrading breaking changes.

By above things, I think it will not be a problem if we drop to build with Go toolchain which is develop branch.