### PR TITLE
Upgrade Go toolchain to v1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-    - "1.13"
+    - "1.14"
     - master
 
 matrix:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/voyagegroup/popuko
 
-go 1.13
+go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1-0.20170626110600-a368813c5e64


### PR DESCRIPTION
* [Blog](https://blog.golang.org/go1.14)
* [Release Note](https://golang.org/doc/go1.14)