### PR TITLE
Support the default branch set by GitHub config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These features are inspired by [homu][homu] and [highfive][highfive].
 - __Patrol pull requests which cannot merge into it after the upstream has been updated__
     - This bot patrols automatically by hooking GitHub's push events.
     - Change the label for the unmergeable pull request and comment about it.
-- __Try the pull request with the latest `master` branch, and merge into it automatically__
+- __Try the pull request with the latest default branch, and merge into it automatically__
     - We call this feature as "Auto-Merging".
 - __Specify a reviewer by a file committed to the repository__
     - This feature is not implemented by homu.
@@ -176,8 +176,6 @@ Auto-Merging behaves like this:
 
 ### The current limitations
 
-- The default branch of your repository should be named as `master`.
-    - [TODO: #196](https://github.com/voyagegroup/popuko/issues/196).
 - If your pull request which try to be merged into non-default branch, this bot does not detect the conflict
   even if the upstream has been changed.
     - [TODO: #197](https://github.com/voyagegroup/popuko/issues/197)

--- a/epic/check_autobranch.go
+++ b/epic/check_autobranch.go
@@ -15,6 +15,7 @@ type StateChangeInfo struct {
 	Status                    string
 	Owner                     string
 	Name                      string
+	DefaultBranch             string
 	NotHandle                 bool
 	ID                        int64
 	SHA                       string
@@ -26,6 +27,7 @@ func CheckAutoBranchWithStatusEvent(ctx context.Context, client *github.Client, 
 		Status:                    *ev.State,
 		Owner:                     *ev.Repo.Owner.Login,
 		Name:                      *ev.Repo.Name,
+		DefaultBranch:             ev.Repo.GetDefaultBranch(),
 		NotHandle:                 *ev.State == "pending",
 		ID:                        *ev.ID,
 		SHA:                       *ev.SHA,
@@ -39,6 +41,7 @@ func CheckAutoBranchWithCheckSuiteEvent(ctx context.Context, client *github.Clie
 		Status:                    *ev.CheckSuite.Conclusion,
 		Owner:                     *ev.Repo.Owner.Login,
 		Name:                      *ev.Repo.Name,
+		DefaultBranch:             ev.Repo.GetDefaultBranch(),
 		NotHandle:                 *ev.CheckSuite.Status != "completed",
 		ID:                        *ev.CheckSuite.ID,
 		SHA:                       *ev.CheckSuite.HeadSHA,
@@ -59,7 +62,7 @@ func checkAutoBranch(ctx context.Context, client *github.Client, autoMergeRepo *
 
 	log.Printf("info: Target repository is %v/%v\n", info.Owner, info.Name)
 
-	repoInfo := GetRepositoryInfo(ctx, client.Repositories, info.Owner, info.Name)
+	repoInfo := GetRepositoryInfo(ctx, client.Repositories, info.Owner, info.Name, info.DefaultBranch)
 	if repoInfo == nil {
 		log.Println("debug: cannot get repositoryInfo")
 		return

--- a/epic/check_autobranch.go
+++ b/epic/check_autobranch.go
@@ -257,7 +257,7 @@ func tryNextItem(ctx context.Context, client *github.Client, owner, name string,
 
 	nextNum := next.PullRequest
 
-	ok, commit := operation.TryWithMaster(ctx, client, owner, name, nextInfo, autoBranch)
+	ok, commit := operation.TryWithDefaultBranch(ctx, client, owner, name, nextInfo, autoBranch)
 	if !ok {
 		log.Printf("info: we cannot try #%v with the latest `master`.", nextNum)
 		return tryNextItem(ctx, client, owner, name, q, autoBranch)

--- a/epic/detect_unmergeable.go
+++ b/epic/detect_unmergeable.go
@@ -98,7 +98,7 @@ func markUnmergeable(ctx context.Context, wg *sync.WaitGroup, info *markUnmergea
 		return
 	}
 
-	if !operation.IsRelatedToMaster(pr, repoOwner, masterBranchName) {
+	if !operation.IsRelatedToDefaultBranch(pr, repoOwner, masterBranchName) {
 		log.Printf("info: #%v is not related to `%v` branch", number, masterBranchName)
 		return
 	}

--- a/epic/detect_unmergeable.go
+++ b/epic/detect_unmergeable.go
@@ -10,23 +10,36 @@ import (
 	"github.com/voyagegroup/popuko/operation"
 )
 
-const masterBranchName = "master"
-
 func DetectUnmergeablePR(ctx context.Context, client *github.Client, ev *github.PushEvent) {
+	owner := *ev.Repo.Owner.Name
+	log.Printf("debug: repository owner is %v\n", owner)
+	repo := *ev.Repo.Name
+	log.Printf("debug: repository name is %v\n", repo)
+
+	fullRepositoryName := owner + "/" + repo
+	defaultBranch := ev.Repo.GetDefaultBranch()
+	if defaultBranch == "" {
+		// I seem we may not require this fallback path. But GitHub API example is not reliable.
+		log.Printf("debug: could not get default branch name from pushed event for %v\n", fullRepositoryName)
+		repoInfo, _, err := client.Repositories.Get(ctx, owner, repo)
+		if err != nil {
+			log.Printf("warn: could not fetch the repository infor for %v by %v\n", fullRepositoryName, err)
+			return
+		}
+
+		defaultBranch = repoInfo.GetDefaultBranch()
+	}
+	log.Printf("info: the default branch name is `%v` for %v\n", defaultBranch, fullRepositoryName)
+
 	// At this moment, we only care a pull request which are looking master branch.
-	if *ev.Ref != "refs/heads/"+masterBranchName {
+	if *ev.Ref != "refs/heads/"+defaultBranch {
 		log.Printf("info: pushed branch is not related to me: %v\n", *ev.Ref)
 		return
 	}
 
-	repoOwner := *ev.Repo.Owner.Name
-	log.Printf("debug: repository owner is %v\n", repoOwner)
-	repo := *ev.Repo.Name
-	log.Printf("debug: repository name is %v\n", repo)
-
 	prSvc := client.PullRequests
 
-	prList, _, err := prSvc.List(ctx, repoOwner, repo, &github.PullRequestListOptions{
+	prList, _, err := prSvc.List(ctx, owner, repo, &github.PullRequestListOptions{
 		State: "open",
 	})
 	if err != nil {
@@ -47,26 +60,28 @@ func DetectUnmergeablePR(ctx context.Context, client *github.Client, ev *github.
 		wg.Add(1)
 
 		go markUnmergeable(ctx, wg, &markUnmergeableInfo{
-			client.Issues,
-			prSvc,
-			repoOwner,
-			repo,
-			*item.Number,
-			comment,
-			semaphore,
+			issueSvc:          client.Issues,
+			prSvc:             prSvc,
+			RepoOwner:         owner,
+			Repo:              repo,
+			DefaultBranchName: defaultBranch,
+			Number:            *item.Number,
+			Comment:           comment,
+			semaphore:         semaphore,
 		})
 	}
 	wg.Wait()
 }
 
 type markUnmergeableInfo struct {
-	issueSvc  *github.IssuesService
-	prSvc     *github.PullRequestsService
-	RepoOwner string
-	Repo      string
-	Number    int
-	Comment   string
-	semaphore chan int
+	issueSvc          *github.IssuesService
+	prSvc             *github.PullRequestsService
+	RepoOwner         string
+	Repo              string
+	DefaultBranchName string
+	Number            int
+	Comment           string
+	semaphore         chan int
 }
 
 func markUnmergeable(ctx context.Context, wg *sync.WaitGroup, info *markUnmergeableInfo) {
@@ -90,6 +105,8 @@ func markUnmergeable(ctx context.Context, wg *sync.WaitGroup, info *markUnmergea
 	log.Printf("debug: repository name is %v\n", repo)
 	number := info.Number
 	log.Printf("debug: pull request number is %v\n", number)
+	defaultBranchName := info.DefaultBranchName
+	log.Printf("debug: the default branch name is %v\n", defaultBranchName)
 
 	pr, _, err := info.prSvc.Get(ctx, repoOwner, repo, number)
 	if err != nil || pr == nil {
@@ -98,8 +115,8 @@ func markUnmergeable(ctx context.Context, wg *sync.WaitGroup, info *markUnmergea
 		return
 	}
 
-	if !operation.IsRelatedToDefaultBranch(pr, repoOwner, masterBranchName) {
-		log.Printf("info: #%v is not related to `%v` branch", number, masterBranchName)
+	if !operation.IsRelatedToDefaultBranch(pr, repoOwner, defaultBranchName) {
+		log.Printf("info: #%v is not related to `%v` branch", number, defaultBranchName)
 		return
 	}
 

--- a/epic/get_repository_config.go
+++ b/epic/get_repository_config.go
@@ -10,10 +10,10 @@ import (
 	"github.com/voyagegroup/popuko/setting"
 )
 
-func GetRepositoryInfo(ctx context.Context, repoSvc *github.RepositoriesService, owner, name string) *setting.RepositoryInfo {
+func GetRepositoryInfo(ctx context.Context, repoSvc *github.RepositoriesService, owner, name, defaultBranchName string) *setting.RepositoryInfo {
 	var repoinfo *setting.RepositoryInfo
 	log.Println("info: Use `OWNERS` file.")
-	ok, owners := fetchOwnersFile(ctx, repoSvc, owner, name)
+	ok, owners := fetchOwnersFile(ctx, repoSvc, owner, name, defaultBranchName)
 	if !ok {
 		log.Println("error: could not handle OWNERS file.")
 		return nil
@@ -28,10 +28,23 @@ func GetRepositoryInfo(ctx context.Context, repoSvc *github.RepositoriesService,
 	return repoinfo
 }
 
-func fetchOwnersFile(ctx context.Context, svc *github.RepositoriesService, owner string, reponame string) (bool, *setting.OwnersFile) {
+func fetchOwnersFile(ctx context.Context, svc *github.RepositoriesService, owner string, reponame string, defaultBranchName string) (bool, *setting.OwnersFile) {
+	fullRepositoryName := owner + "/" + reponame
+	if defaultBranchName == "" {
+		log.Printf("debug: could not get default branch name from the event for %v\n", fullRepositoryName)
+		repoInfo, _, err := svc.Get(ctx, owner, reponame)
+		if err != nil {
+			log.Printf("warn: could not fetch the repository infor for %v by %v\n", fullRepositoryName, err)
+			return false, nil
+		}
+
+		defaultBranchName = repoInfo.GetDefaultBranch()
+	}
+	log.Printf("info: the default branch name is `%v` for %v\n", defaultBranchName, fullRepositoryName)
+
 	file, err := svc.DownloadContents(ctx, owner, reponame, "OWNERS.json", &github.RepositoryContentGetOptions{
 		// We always use the file in master which we regard as accepted to the project.
-		Ref: "master",
+		Ref: defaultBranchName,
 	})
 	if err != nil {
 		log.Printf("error: could not fetch `OWNERS.json`: %v\n", err)

--- a/operation/branch.go
+++ b/operation/branch.go
@@ -42,7 +42,7 @@ func createAutoBranch(ctx context.Context, svc *github.GitService, owner string,
 	return true, ref
 }
 
-func TryWithMaster(ctx context.Context, client *github.Client, owner string, name string, info *github.PullRequest, autoBranch string) (bool, string) {
+func TryWithDefaultBranch(ctx context.Context, client *github.Client, owner string, name string, info *github.PullRequest, autoBranch string) (bool, string) {
 	number := *info.Number
 
 	ok, ref := createAutoBranch(ctx, client.Git, owner, name, number, autoBranch)

--- a/operation/pull_request.go
+++ b/operation/pull_request.go
@@ -42,7 +42,7 @@ func isMergeable(ctx context.Context, prSvc *github.PullRequestsService, owner, 
 	return true, *mergeable
 }
 
-func IsRelatedToMaster(pr *github.PullRequest, owner, master string) bool {
+func IsRelatedToDefaultBranch(pr *github.PullRequest, owner, master string) bool {
 	base := pr.Base
 	if base == nil {
 		log.Printf("info: #%v's Base is `nil`\n", *pr.Number)

--- a/server.go
+++ b/server.go
@@ -118,7 +118,8 @@ func (srv *AppServer) processIssueCommentEvent(ctx context.Context, ev *github.I
 		return false, fmt.Errorf("error: unexpected result of parsing comment body")
 	}
 
-	repoInfo := epic.GetRepositoryInfo(ctx, srv.githubClient.Repositories, repoOwner, repo)
+	defaultBranchName := ev.Repo.GetDefaultBranch()
+	repoInfo := epic.GetRepositoryInfo(ctx, srv.githubClient.Repositories, repoOwner, repo, defaultBranchName)
 	if repoInfo == nil {
 		return false, fmt.Errorf("debug: cannot get repositoryInfo")
 	}


### PR DESCRIPTION
* Fix https://github.com/voyagegroup/popuko/issues/196
    * [GitHub will change the default branch name for a new repository](https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/). So we need to fix this bug.
* By [the document for GitHub webhook](https://developer.github.com/webhooks/event-payloads/), we can get the branch name from a webhook event. But I cannot trust their document and their examples are sometimes different actual json payload. Thus I added a fallback path as the workaround.
    * In the worst case, this bot will increase 1 API request per events.