### PR TITLE
Skip Checks API neutral state

### DIFF
--- a/epic/check_autobranch.go
+++ b/epic/check_autobranch.go
@@ -183,6 +183,11 @@ func mergeSucceedItem(
 		return true
 	}
 
+	if info.Status == "neutral" {
+		log.Println("info: natural event received. could not determine test succeeded or not")
+		return true
+	}
+
 	if info.Status != "success" {
 		log.Println("info: could not merge pull request")
 

--- a/epic/check_autobranch.go
+++ b/epic/check_autobranch.go
@@ -146,18 +146,6 @@ func isRelatedToAutoBranchBodyWithCheckSuiteEvent(ev *github.CheckSuiteEvent) fu
 	}
 }
 
-func inProgressWithStatusEvent(ev *github.StatusEvent) func() bool {
-	return func() bool {
-		return *ev.State == "pending"
-	}
-}
-
-func inProgressWithCheckSuiteEvent(ev *github.CheckSuiteEvent) func() bool {
-	return func() bool {
-		return *ev.CheckSuite.Status != "completed" || *ev.CheckSuite.Conclusion == "neutral"
-	}
-}
-
 func isRelatedToAutoBranch(active *queue.AutoMergeQueueItem, info StateChangeInfo, autoBranch string) bool {
 	if !info.IsRelatedToAutoBranchBody(autoBranch) {
 		log.Printf("warn: this event (%v) is not the auto branch\n", info.ID)

--- a/epic/check_autobranch.go
+++ b/epic/check_autobranch.go
@@ -324,6 +324,11 @@ func mergeSucceedItemWithCheckSuiteEvent(
 		return true
 	}
 
+	if info.Conclusion == "neutral" {
+		log.Printf("info: Check Status is not determined\n")
+		return true
+	}
+
 	if info.Conclusion != "success" {
 		log.Println("info: could not merge pull request")
 


### PR DESCRIPTION
We use CircleCI for CI.
Recently it will returns a `neutral` state before state is determined by the CI.
In the current code, except for `success`, it is designed to be considered a failure.
https://github.com/voyagegroup/popuko/blob/71080116e305bb469dd35732e11a0199fdaa4ecd/epic/check_autobranch.go#L186
I thought it would be better to skip the decision for `neutral`, which cannot be determined as success or failure, so I added that process.

<img width="458" alt="スクリーンショット 2021-11-15 18 51 04" src="https://user-images.githubusercontent.com/1955233/141760313-4199c2b6-bf41-457f-88cb-749c6209ab3a.png">

Webhook payload
```
{
  "action": "completed",
  "check_suite": {
    "id":,
    "node_id": "",
    "head_branch": "master",
    "head_sha": "",
    "status": "completed", <- completed???? test is running...
    "conclusion": "neutral", <- 
    "url": "",
    "before": "",
    "after": "",
    "pull_requests": [

    ],
   ...
}
```